### PR TITLE
Set maxlength of 300 characters

### DIFF
--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -83,6 +83,7 @@ class Index extends React.Component {
             <input
               type="text"
               value={this.state.text}
+              maxlength="300"
               onChange={this.handleTextChange}
               style={{ width: '90%' }}
             />
@@ -115,7 +116,8 @@ class Index extends React.Component {
           </div>
         </form>
 
-        <br />
+        <p>Text has a maximum length of 300 characters.</p>
+
         <ReactAudioPlayer
           src={this.state.audioUrl}
           style={{

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -116,7 +116,7 @@ class Index extends React.Component {
           </div>
         </form>
 
-        <p>Text has a maximum length of 300 characters.</p>
+        <br>
 
         <ReactAudioPlayer
           src={this.state.audioUrl}


### PR DESCRIPTION
After some testing, I have found that there seems to be a maximum length of text that is allowed to be spoken, this length is 300 characters. This limit isn't mentioned anywhere nor is it imposed.

This is a simple commit that does just that.